### PR TITLE
Fix issue #7, contribute to #3

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -695,11 +695,13 @@ languages["es"] = {
     "fullLinkTitle" : "Mostrar mensaje completo",
     "refreshLinkTitle" : "Consultar nuevos correos",
     "optionsLinkTitle" : "Ir a la página de opciones",
+    "sendPageLinkTitle" : "Enviar link a pagina",
     "composeLinkTitle" : "Redactar nuevo correo",
     "noUnreadText" : "No tienes correos sin leer",
     "oneUnreadText" : "correo sin leer", // One unread item: "1 unread mail"
     "severalUnreadText" : "correos sin leer", // Several unread items: "3 unread mail"
-    "popupText" : "Has recibido un nuevo correo!"
+    "popupText" : "Has recibido un nuevo correo!",
+    "showLabelsTitle" : "Mostrar etiquetas"
 };
 
 // Swedish

--- a/src/popup.js
+++ b/src/popup.js
@@ -179,10 +179,6 @@ function sendReply(mailid) {
 
 function getThread(accountId, mailid) {
 
-   if (Settings.read("showfull_read")) {
-	  readThread(accountId, mailid, true);
-   }
-
    if (mailCache[mailid] != null) {
       // Mail already fetched, read from cache instead
       showBody(accountId, mailid, mailCache[mailid]);
@@ -201,6 +197,10 @@ function showBody(accountid, mailid, mailbody) {
    //   hideElement(mailid + "_more-link");
 
    if (mailbody != null) {
+
+      if (Settings.read("showfull_read")) {
+         readThread(accountid, mailid, true);
+      }
 
       var previousMail = null;
       var nextMail = null;


### PR DESCRIPTION
Previewing now marks emails as read correctly if the setting is enabled. It was just a simple race condiction. I simply relocated the mark-as-read call to be done once the email is fully loaded.

I also added some translations for spanish that were missing.
